### PR TITLE
feat: use subscription for `isDirty`

### DIFF
--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -244,20 +244,37 @@ describe("Form: handleSubmit", () => {
 
     expect(stopPropagation).toHaveBeenCalledOnce();
   });
-});
 
-it("Return true when the inicial value is modified", () => {
-  const initialValues = { name: "Lorem", last: "Ipsum" };
-    const form = newForm<typeof initialValues>({
-      initialValues,
-      onSubmit: vi.fn(),
-    });
-    
-    expect(get(form.isDirty)).toStrictEqual(false);
+  it("isDirty is `true` when initial values differ from current (imperative)", () => {
+    const initialValues = { name: "Lorem", last: "Ipsum" };
+      const form = newForm<typeof initialValues>({
+        initialValues,
+        onSubmit: vi.fn(),
+      });
+      
+      expect(get(form.isDirty)).toStrictEqual(false);
+  
+      form.setFieldValue('name', 'John');
+  
+      expect(get(form.isDirty)).toStrictEqual(true);
+  });
 
-    form.setFieldValue('name', 'John');
-
-    expect(get(form.isDirty)).toStrictEqual(true);
+  it("isDirty is `true` when initial values differ from current (store subscription)", () => {
+    const initialValues = { name: "Lorem", last: "Ipsum" };
+      const form = newForm<typeof initialValues>({
+        initialValues,
+        onSubmit: vi.fn(),
+      });
+      
+      expect(get(form.isDirty)).toStrictEqual(false);
+  
+      form.values.update((values) => ({
+        ...values,
+        name: 'John',
+      }));
+  
+      expect(get(form.isDirty)).toStrictEqual(true);
+  });
 });
 
 describe("Form: setInitialValues", () => {


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Subscribes to the `values` store to run `isDirty` side effect. This opens path to other observables we may introduce in the future.