### PR TITLE
fix(form): support error object for `abortEarly: true`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,11 @@ export type FormInstance<T extends object> = {
 
 export type FormConfig<T extends object> = {
   /**
+   * If `true`, validation errors are printed to the console.
+   */
+  debug?: boolean;
+
+  /**
    * Form's fields initial values.
    *
    * This object is required to initialize a new form, it's used to track
@@ -529,7 +534,21 @@ export const newForm: NewFormFn = <T extends object>(
                 : { abortEarly: false },
             );
           } catch (error) {
-            console.warn(error);
+            if (config.debug) {
+              console.warn(error);
+            }
+
+            if (config.validationOptions?.abortEarly) {
+              const field = error.path as keyof T;
+              const message = error.errors[0];
+
+              __errors.set({
+                [field]: message,
+              } as FormErrors<T>);
+
+              return;
+            }
+
             if (error?.inner) {
               const validationErrors = error.inner.reduce(
                 (acc: FormErrors<T>, { message, path }) => {

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -299,3 +299,117 @@ describe("Form: setInitialValues", () => {
     expect(get(form.initialValues).lastName).toStrictEqual("Angelo");
   });
 });
+
+describe("Yup Validation Options: abortEarly error reporting behavior", () => {
+  it("Reports all the available errors by default ({ abortEarly: false })", async () => {
+    const form = newForm({
+      initialValues: {
+        name: "",
+        lastName: "",
+      },
+      onSubmit: vi.fn(),
+      validationSchema: Yup.object({
+        name: Yup.string().required("You must provide the name."),
+        lastName: Yup.string().required("You must provide the last name."),
+      }),
+    });
+
+    await form.handleSubmit({} as Event);
+
+    const errors = get(form.errors);
+
+    expect(errors.name).toStrictEqual("You must provide the name.");
+    expect(errors.lastName).toStrictEqual("You must provide the last name.");
+    expect(Object.keys(errors).length).toStrictEqual(2);
+  });
+
+  it("Reports first error when `abortEarly` is `true` ({ abortEarly: true })", async () => {
+    const form = newForm({
+      initialValues: {
+        name: "",
+        lastName: "",
+      },
+      onSubmit: vi.fn(),
+      validationSchema: Yup.object({
+        name: Yup.string().required("You must provide the name."),
+        lastName: Yup.string().required("You must provide the last name."),
+      }),
+      validationOptions: {
+        abortEarly: true,
+      }
+    });
+
+    await form.handleSubmit({} as Event);
+
+    const errors = get(form.errors);
+
+    expect(errors.name).toBeUndefined();
+    expect(errors.lastName).toStrictEqual('You must provide the last name.');
+    expect(Object.keys(errors).length).toStrictEqual(1);
+  });
+});
+
+describe("Form: setInitialValues", () => {
+  it("Sets form initial values", () => {
+    const form = newForm({
+      initialValues: {
+        name: "James",
+        lastName: "Gordon",
+      },
+      onSubmit: vi.fn(),
+    });
+
+    expect(get(form.initialValues).name).toStrictEqual("James");
+    expect(get(form.initialValues).lastName).toStrictEqual("Gordon");
+
+    form.setInitialValues({
+      name: "Steve",
+      lastName: "Angelo",
+    });
+
+    expect(get(form.initialValues).name).toStrictEqual("Steve");
+    expect(get(form.initialValues).lastName).toStrictEqual("Angelo");
+  });
+});
+
+describe("Form Debug Behavior", () => {
+  it("Logs warning on validation error when `debug` option is set to `true`", async () => {
+    const consoleMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const form = newForm({
+      initialValues: {
+        name: "",
+        lastName: "",
+      },
+      onSubmit: vi.fn(),
+      validationSchema: Yup.object({
+        name: Yup.string().required("You must provide the name."),
+        lastName: Yup.string().required("You must provide the last name."),
+      }),
+      debug: true,
+    });
+
+    await form.handleSubmit({} as Event);
+
+    expect(consoleMock).toHaveBeenCalledOnce();
+  });
+
+  it("Do not log warnings on validation error when `debug` option is unset", async () => {
+    const consoleMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const form = newForm({
+      initialValues: {
+        name: "",
+        lastName: "",
+      },
+      onSubmit: vi.fn(),
+      validationSchema: Yup.object({
+        name: Yup.string().required("You must provide the name."),
+        lastName: Yup.string().required("You must provide the last name."),
+      }),
+      debug: false,
+    });
+
+    await form.handleSubmit({} as Event);
+
+    expect(consoleMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes issue where having `abortEarly: true` affect Form update behavior by leaving `error`
Readable Store empty.

Also adds missing tests.

Also provides `debug` option to silence warnings on production.
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
